### PR TITLE
Remove the unnecessary and dangerous `mem-set` in finalizer

### DIFF
--- a/unboxables.lisp
+++ b/unboxables.lisp
@@ -47,10 +47,7 @@
                                   :element-ctype ',(type-ctype name)
                                   :element-size ,size
                                   :total-size ,size)))
-          (tg:finalize ,struct (lambda ()
-                                 (cffi:foreign-free ,struct-ptr)
-                                 (setf (cffi:mem-ref ,struct-ptr :pointer)
-                                       (cffi:null-pointer))))
+          (tg:finalize ,struct (lambda () (cffi:foreign-free ,struct-ptr)))
           ,@(loop :for field :in field-infos
                   :collect
                   (with-slots ((field-name name) offset ctype size initform)


### PR DESCRIPTION
The `(setf (mem-ref ...) ...)` here is unnecessary and writing data to a memory that has already been released will cause a segmentation fault, leading to a crash of the Lisp session:

https://github.com/digikar99/unboxables/blob/7f877eb39caa6d018e86a2c62d1afd68d2a215c7/unboxables.lisp#L50-L53